### PR TITLE
feat: add godwoken testnet v1.0 support

### DIFF
--- a/src/assets.ts
+++ b/src/assets.ts
@@ -41,3 +41,10 @@ export const CLO: IAssetData = {
   decimals: "18",
   contractAddress: "",
 };
+
+export const pCKB: IAssetData = {
+  symbol: "pCKB",
+  name: "pCKB",
+  decimals: "18",
+  contractAddress: "",
+};

--- a/src/chains.ts
+++ b/src/chains.ts
@@ -1,5 +1,5 @@
 import { IChainData } from "./types";
-import { CLO, ETH, MATIC, POA, RSK, xDAI } from "./assets";
+import { CLO, ETH, MATIC, pCKB, POA, RSK, xDAI } from "./assets";
 
 const supportedChains: IChainData[] = [
   {
@@ -171,6 +171,16 @@ const supportedChains: IChainData[] = [
     network_id: 10,
     rpc_url: "https://mainnet.optimism.io/",
     native_currency: ETH,
+  },
+  {
+    name: "Godwoken Testnet v1.0",
+    short_name: "gwtest1",
+    chain: "Godwoken",
+    network: "testnet",
+    chain_id: 868455272153094,
+    network_id: 868455272153094,
+    rpc_url: "https://godwoken-testnet-web3-v1-rpc.ckbapp.dev/",
+    native_currency: pCKB,
   },
 ];
 


### PR DESCRIPTION
Context: WalletConnect example page seems to be failing with "unsupported chain id" message. Please take a look at this PR adding first UTXO optimistic rollup that's compatible with EVM

cc @pedrouid 